### PR TITLE
feat!: the `general.secret_key` configuration field is now required

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ See the `defaults/main.yml` file for details.
 
 - `libretime_public_url` defines the public url used to access Libretime. This variable **MUST** be updated.
 - `libretime_api_key` define the api key. This variable **MUST** be updated.
+- `libretime_secret_key` define the secret key. This variable **MUST** be updated.
 
 - `libretime_config_template` defines the path to your configuration template file. This variable **SHOULD** be updated. This is used to let you deploy your own configuration file, you can find an example in `templates/libretime/config.yml.j2`.
 
@@ -51,7 +52,8 @@ See the `requirements.yml` file for details.
     - role: libretime
       libretime_public_url: https://station.radio.org
       libretime_listen_port: 8080
-      libretime_api_key: a182_your_secret_key_c87f
+      libretime_api_key: a182_your_api_key_c87f
+      libretime_secret_key: 0fd9_your_secret_key_4521
       libretime_icecast_admin_password: 0fd9ba81394a91cd178514e3c6788052
       libretime_icecast_source_password: ee41c264d954b92fce44521e02663d89
       libretime_icecast_relay_password: 9702d35f24d77ce8cb2da75ab2298654

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,6 +25,8 @@ provisioner:
       instance1:
         libretime_public_url: http://localhost:{{ libretime_listen_port }}/
         libretime_listen_port: 9001
+        libretime_api_key: hackme
+        libretime_secret_key: hackme
         libretime_playout_pip_extras: [sentry]
         libretime_playout_systemd_override: |
           [Service]
@@ -32,6 +34,8 @@ provisioner:
       instance2:
         libretime_public_url: http://localhost:{{ libretime_listen_port }}/
         libretime_listen_port: 9002
+        libretime_api_key: hackme
+        libretime_secret_key: hackme
 
 verifier:
   name: testinfra

--- a/templates/libretime/config.yml.j2
+++ b/templates/libretime/config.yml.j2
@@ -7,6 +7,9 @@ general:
   # The internal API authentication key.
   # > this field is REQUIRED
   api_key: {{ libretime_api_key }}
+  # The Django API secret key.
+  # > this field is REQUIRED
+  secret_key: {{ libretime_secret_key }}
 
   # List of origins allowed to access resources on the server, the public url
   # origin is automatically included.


### PR DESCRIPTION
Related to https://github.com/libretime/libretime/pull/2834

BREAKING CHANGE: The `general.secret_key` configuration field is now required. Make sure to update your configuration file and add a secret key.