### PR TITLE
fix: pin pip version to <21.4 to allow installing pytz (celery)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,7 +105,7 @@
 
 - name: Setup python3 environment
   ansible.builtin.pip:
-    name: [pip, setuptools, wheel]
+    name: [pip<21.4, setuptools, wheel]
     state: latest # noqa package-latest
     virtualenv: "{{ libretime_venv_dir }}"
     virtualenv_command: python3 -m venv


### PR DESCRIPTION
Related to https://github.com/libretime/libretime/issues/2983