### PR TITLE
feat: add legacy fastcgi cache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,7 @@ libretime_api_systemd_override:
 ########################################################################################
 libretime_legacy_managed: true
 libretime_legacy_web_root: /usr/share/libretime/legacy
+libretime_legacy_cache_paths: []
 
 # > Postgresql
 ########################################################################################

--- a/templates/nginx/libretime.conf.j2
+++ b/templates/nginx/libretime.conf.j2
@@ -1,3 +1,16 @@
+{% if libretime_legacy_cache_paths -%}
+fastcgi_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=legacy:100m;
+fastcgi_cache_key "$request_method$scheme$host$request_uri";
+
+map $request_uri $no_cache {
+  default "1";
+{% for path in libretime_legacy_cache_paths %}
+  "{{ path }}" "0";
+{% endfor %}
+}
+
+{% endif -%}
+
 server {
   listen {{ libretime_listen_port }};
   listen [::]:{{ libretime_listen_port }};
@@ -21,12 +34,19 @@ server {
     # try_files $uri =404;
     try_files $fastcgi_script_name =404;
 
-    include fastcgi_params;
-
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     set $path_info $fastcgi_path_info;
     fastcgi_param PATH_INFO $path_info;
     include fastcgi_params;
+
+    {% if libretime_legacy_cache_paths -%}
+    fastcgi_cache legacy;
+    fastcgi_cache_valid 200 5s;
+
+    fastcgi_no_cache      $no_cache;
+    fastcgi_cache_bypass  $no_cache;
+
+    {% endif -%}
 
     fastcgi_index index.php;
     fastcgi_pass unix:/run/libretime-legacy.sock;


### PR DESCRIPTION
This allows the users to cache requests using the nginx fastcgi cache.

A good use case is to enable the cache for the `/api/live-info` and `/api/week-info` endpoints. 